### PR TITLE
chore: update Python to 3.13, PostgreSQL to 17, GitHub Actions to latest

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync
@@ -35,19 +35,19 @@ jobs:
     if: ${{ github.event_name == 'push' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 RUN apt-get update && apt-get install -yqq \
     make \
-    postgresql-15 \
+    postgresql-17 \
     sudo \
     curl
 
@@ -22,8 +22,8 @@ COPY . .
 COPY init.sql /docker-entrypoint-initdb.d/
 
 # postgres config
-RUN echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/15/main/pg_hba.conf && \
-    echo "listen_addresses='*'" >> /etc/postgresql/15/main/postgresql.conf
+RUN echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/17/main/pg_hba.conf && \
+    echo "listen_addresses='*'" >> /etc/postgresql/17/main/postgresql.conf
 
 # create docker user and db
 RUN service postgresql start && \


### PR DESCRIPTION
## Summary

- **Python**: 3.12 → 3.13 (Dockerfile + CI)
- **PostgreSQL**: 15 → 17 (Dockerfile + config paths `/etc/postgresql/17/main/`)
- **actions/checkout**: v4 → v5
- **actions/setup-python**: v5 → v6
- **astral-sh/setup-uv**: v5 → v7
- **docker/login-action**: v3 → v4
- **docker/build-push-action**: v6 → v7

Closes all open Dependabot PRs (#14, #15, #16, #17, #18).