### PR TITLE
fix: не поднимать базовый образ до релиз-кандидата питона

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,11 @@ updates:
     labels: ["dependencies", "automated"]
     commit-message:
       prefix: "chore"
+    # Теги питона включают релиз-кандидаты и альфы, и Dependabot предлагал
+    # поднять базовый образ до 3.15.0rc1.
+    ignore:
+      - dependency-name: "python"
+        versions: ["*rc*", "*a[0-9]*", "*b[0-9]*"]
     groups:
       docker-all:
         patterns: ["*"]


### PR DESCRIPTION
Теги образа `python` включают релиз-кандидаты и альфы, и Dependabot предложил `3.15.0rc1-slim` как обычное обновление (`python-django-blog#11`). Предрелизные теги исключены во всех трёх python-репозиториях пачки, у которых есть Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)